### PR TITLE
Add Validation for EdgeIX Peer on addasn

### DIFF
--- a/bgp.py
+++ b/bgp.py
@@ -169,6 +169,24 @@ class RouteServerInteraction(object):
                 )
         return f'```{table}```', route_server_data['name']
     
+    def is_peer(self, asn: int) -> bool:
+        """
+            Check if a given ASN is a Configured Peer
+            of any Route Server
+
+            Arguments:
+                asn (int): ASN to check
+            
+            Returns:
+                bool: True if ASN exists
+        """
+        if isinstance(asn, str):
+            asn = self._int_convert(asn)
+            if not asn:
+                return False
+
+        return True if asn in self.asns.keys() else False
+    
     def _load_bird_data(self) -> dict:
         """
             Inner function to obtain data from IXPM, adds
@@ -186,7 +204,7 @@ class RouteServerInteraction(object):
                     rsd['error'] = True
 
         return self.route_servers
-    
+
     @property
     def asns(self) -> dict:
         """

--- a/bot.py
+++ b/bot.py
@@ -64,18 +64,25 @@ async def add_asn(ctx, *, message):
     if match:
         asn = f'AS{message}'
         user = ctx.message.author
+
         if get(ctx.guild.roles, name=asn):
             await user.add_roles(discord.utils.get(ctx.guild.roles, name=asn))
-            embed = await format_message('Role Addition', f'Successfully added {asn} to {user.display_name}')
-            await ctx.send(embed=embed)
+            response = f'Successfully added {asn} to {user.display_name}'
         else:
             role = await ctx.guild.create_role(name=asn)
             await user.add_roles(role)
-            embed = await format_message('Role Addition', f'Successfully created and added {asn} to {user.display_name}')
-            await ctx.send(embed=embed)
+            response = f'Successfully created and added {asn} to {user.display_name}'
+        
+        # Lets check if the ASN is a valid EdgeIX Peer (Configured via RS)
+        if RouteServers.is_peer(int(message)):
+            response = f'{asn} is a Valid EdgeIX Peer!\n\n{response}'
+            await user.add_roles(discord.utils.get(ctx.guild.roles, name='peer'))
+
     else:
         embed = format_message('Role Addition', f'Please enter a valid ASN. You provided: {message}')
-        await ctx.send(embed=embed)  
+
+    embed = await format_message('Role Addition', response)
+    await ctx.send(embed=embed)  
 
 
 @bot.command(name="removeasn",


### PR DESCRIPTION
Validate if an ASN is a part of the EdgeIX Fabric (configured on any route server, doesn't have to be active) & assign a special "peer" role. 